### PR TITLE
Terminate crashpad_handler as soon as we finish with Gradle invocation during instrumentation

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -277,7 +277,20 @@ jobs:
       - name: "Prepare script to run."
         id: script
         env:
-          SCRIPT: ${{ inputs.script }}
+          SCRIPT: |
+            # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/373
+            pre_terminate_crashpad() {
+              # For some reason pgrep/pkill sees only crashpad_handle, not crashpad_handler,
+              # but it's definitely called ${ANDROID_HOME}/emulator/crashpad_handler.
+              
+              # Best-effort gracefully terminate all crashpad_handler processes.
+              pkill --exact --echo --signal SIGTERM crashpad_handle || return
+              sleep 10
+              pkill --exact --echo --signal SIGKILL crashpad_handle || return
+            }
+            trap pre_terminate_crashpad EXIT
+            
+            ${{ inputs.script }}
         run: |
           script_file="${RUNNER_TEMP}/reactivecircus-android-emulator-runner-prepared-script.sh"
           echo "${SCRIPT}" > "${script_file}"

--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -218,7 +218,7 @@ jobs:
             ~/.android/avd/test.avd/
             ~/.android/adbkey
             ~/.android/adbkey.pub
-          DEVICE: ${{ steps.emulator.outputs.profile }}-${{ steps.emulator.outputs.sdcard }}
+          DEVICE: "${{ steps.emulator.outputs.profile }}-${{ steps.emulator.outputs.sdcard }}"
           PACKAGE: system-images;android-${{ steps.emulator.outputs.api-level }};${{ steps.emulator.outputs.target }};${{ steps.emulator.outputs.arch }}
           HASH: ${{ hashFiles('setup-script.sh') }}
         run: |

--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -8,20 +8,24 @@ on:
         required: true
         type: string
         description: |
-          Lines of script to execute while the emulator is running.
+          Script to execute while the emulator is running.
+          Scripting language is bash.
           Usually this is a `gradlew connectedCheck` command in some form.
-          Multiple lines are allowed, but due to reactivecircus/android-emulator-runner's behavior
-          each line will be executed separately, so no backslashes at end of lines.
-          Note: in yaml, you can still use > to write multiple lines that end up as a single-line string.
+          
+          Contrary to reactivecircus/android-emulator-runner's behavior,
+          multi-line scripts are allowed.
+          (See https://github.com/ReactiveCircus/android-emulator-runner/issues/391.)
 
       setup-script:
         required: false
         type: string
         description: |
           Initial setup, gets cached in the emulator snapshot.
-          Multiple lines are allowed, but due to reactivecircus/android-emulator-runner's behavior
-          each line will be executed separately, so no backslashes at end of lines.
-          Note: in yaml, you can still use > to write multiple lines that end up as a single-line string.
+          Scripting language is bash.
+          
+          Contrary to reactivecircus/android-emulator-runner's behavior,
+          multi-line scripts are allowed.
+          (See https://github.com/ReactiveCircus/android-emulator-runner/issues/391.)
 
       android-api:
         required: true
@@ -190,7 +194,6 @@ jobs:
       - name: "Calculate emulator properties"
         id: emulator
         env:
-          SETUP_SCRIPT: ${{ inputs.setup-script }}
           API: ${{ inputs.android-api }}
           TARGET: ${{ inputs.android-api >= 32 && 'google_apis' || 'default' }}
           ARCH: ${{ inputs.android-api >= 21 && 'x86_64' || 'x86' }}
@@ -204,9 +207,17 @@ jobs:
           echo "sdcard=100M" >> "${GITHUB_OUTPUT}"
           # See https://developer.android.com/studio/run/emulator-commandline#common
           echo "options=-no-window -gpu swiftshader_indirect -noaudio -no-boot-anim" >> "${GITHUB_OUTPUT}"
+
+      # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/391
+      - name: "Prepare setup script to run."
+        id: setup-script
+        env:
+          SCRIPT: ${{ inputs.setup-script }}
+        run: |
+          script_file="${RUNNER_TEMP}/reactivecircus-android-emulator-runner-prepared-setup-script.sh"
           # Need to exist before substituting hashFiles in the next step.
-          echo "${SETUP_SCRIPT}" > setup-script.sh
-          chmod +x setup-script.sh
+          echo "${SCRIPT}" > "${script_file}"
+          echo "file=${script_file}" >> "${GITHUB_OUTPUT}"
 
       - name: "Calculate cache properties"
         if: ${{ inputs.cache }}
@@ -220,7 +231,7 @@ jobs:
             ~/.android/adbkey.pub
           DEVICE: "${{ steps.emulator.outputs.profile }}-${{ steps.emulator.outputs.sdcard }}"
           PACKAGE: system-images;android-${{ steps.emulator.outputs.api-level }};${{ steps.emulator.outputs.target }};${{ steps.emulator.outputs.arch }}
-          HASH: ${{ hashFiles('setup-script.sh') }}
+          HASH: ${{ hashFiles(steps.setup-script.outputs.file) }}
         run: |
           echo -e "cache-paths<<EOF\n${CACHE_PATHS}\nEOF" >> "${GITHUB_OUTPUT}"
           echo "cache-key=android-emulator-${DEVICE}-${PACKAGE}-${HASH}-v1" >> "${GITHUB_OUTPUT}"
@@ -251,7 +262,7 @@ jobs:
           emulator-options: ${{ steps.emulator.outputs.options }} -no-snapshot-load
           script: |
             adb devices -l
-            ./setup-script.sh
+            bash --noprofile --norc -eo pipefail "${{ steps.setup-script.outputs.file }}"
 
       - name: "Save AVD cache"
         id: avd-cache-save
@@ -261,6 +272,16 @@ jobs:
         with:
           path: ${{ steps.cache-helper.outputs.cache-paths }}
           key: ${{ steps.avd-cache-restore.outputs.cache-primary-key }}
+
+      # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/391
+      - name: "Prepare script to run."
+        id: script
+        env:
+          SCRIPT: ${{ inputs.script }}
+        run: |
+          script_file="${RUNNER_TEMP}/reactivecircus-android-emulator-runner-prepared-script.sh"
+          echo "${SCRIPT}" > "${script_file}"
+          echo "file=${script_file}" >> "${GITHUB_OUTPUT}"
 
       - name: "Run Instrumentation Tests on emulator."
         id: gradle
@@ -279,7 +300,7 @@ jobs:
           emulator-options: ${{ steps.emulator.outputs.options }} -no-snapshot-save
           script: |
             adb devices -l
-            ${{ inputs.script }}
+            bash --noprofile --norc -eo pipefail "${{ steps.script.outputs.file }}"
 
       - name: "Publish 'Gradle' result and Build Scan URL."
         if: ${{ (success() || failure()) && steps.gradle != null && steps.gradle.outputs.result-success != null }}


### PR DESCRIPTION
 * Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/373
 * Also contains workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/391