### PR TITLE
Enable Gradle caching for instrumentation tests

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -185,6 +185,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: "Set up Gradle."
+        uses: gradle/actions/setup-gradle@v3
+
       - name: "Enable KVM."
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -187,8 +187,6 @@ jobs:
 
       - name: "Set up Gradle."
         uses: gradle/actions/setup-gradle@v3
-        with:
-          cache-read-only: false
 
       - name: "Enable KVM."
         run: |

--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -187,6 +187,8 @@ jobs:
 
       - name: "Set up Gradle."
         uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: false
 
       - name: "Enable KVM."
         run: |


### PR DESCRIPTION
![image](https://github.com/TWiStErRob/github-workflows/assets/2906988/f4364eb6-06ef-48d8-a738-c8d2692c5d2d)

Instrumentation and Build are executing very similar tasks, they shouldn't take this much different time.