### PR TITLE
Workaround github/codeql-action#3156 by renaming

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -63,12 +63,19 @@ jobs:
           if-no-files-found: error
           path: ${{ steps.ghlint.outputs.sarif-report }}
 
+      # Workaround for https://github.com/github/codeql-action/issues/3156
+      - name: "Rename .sarif.json to just .sarif"
+        shell: bash
+        env:
+          SARIF_PATH: ${{ steps.ghlint.outputs.sarif-report }}
+        run: mv "${SARIF_PATH}" ghlint.sarif
+
       - name: "Publish 'GH-Lint' GitHub Code Scanning analysis."
         if: ${{ success() || failure() }}
-        uses: github/codeql-action/upload-sarif@v3.30.3
+        uses: github/codeql-action/upload-sarif@v3.30.4
         with:
           checkout_path: ${{ github.workspace }}
-          sarif_file: ${{ steps.ghlint.outputs.sarif-report }}
+          sarif_file: ${{ github.workspace }}/ghlint.sarif
 
 
   renovate:


### PR DESCRIPTION
Re-workaround https://github.com/github/codeql-action/issues/3156 while keeping the action up to date.